### PR TITLE
Add a build:linux target

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ yarn build:mac
 # ... Win32
 yarn build:win
 
+# ... Linux
+yarn build:linux
+
 # run Jest's unit tests
 yarn test
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "electron-webpack dev",
     "compile": "electron-webpack",
     "build:mac": "yarn compile && electron-builder -m",
-    "build:win": "yarn compile && electron-builder -w"
+    "build:win": "yarn compile && electron-builder -w",
+    "build:linux": "yarn compile && electron-builder -l"
   },
   "build": {
     "appId": "com.jukben.lcp",


### PR DESCRIPTION
This generates an AppImage, which works fine on both Debian stable and unstable (and likely pretty much everywhere else too). Added a note about it to the README too.